### PR TITLE
Added smoothing for camera offset

### DIFF
--- a/Assets/Scripts/CameraOffset.cs
+++ b/Assets/Scripts/CameraOffset.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CameraOffset : MonoBehaviour
+{
+    [SerializeField] private CinemachineCameraOffset _cco;
+    [SerializeField] private float offsetSpeed = 17.0f;
+    [SerializeField] private float offsetThreshold = 0.05f;
+
+    public void OffsetTo(Vector3 offset, float ts)
+    {
+        if (Vector3.Magnitude(offset - _cco.m_Offset) < offsetThreshold)
+        {
+            _cco.m_Offset = offset;
+            return;
+        }
+        // _cco.m_Offset = offset;
+        _cco.m_Offset = Vector3.Lerp(_cco.m_Offset, offset, offsetSpeed * ts);
+    }
+}

--- a/Assets/Scripts/CameraOffset.cs
+++ b/Assets/Scripts/CameraOffset.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -5,17 +6,23 @@ using UnityEngine;
 public class CameraOffset : MonoBehaviour
 {
     [SerializeField] private CinemachineCameraOffset _cco;
-    [SerializeField] private float offsetSpeed = 17.0f;
+    [SerializeField] private float offsetSpeed = 10.0f;
     [SerializeField] private float offsetThreshold = 0.05f;
+    private Vector3 _cursorOffset = Vector3.zero;
 
-    public void OffsetTo(Vector3 offset, float ts)
+    public void OffsetTo(Vector3 offset)
     {
-        if (Vector3.Magnitude(offset - _cco.m_Offset) < offsetThreshold)
+        _cursorOffset = offset;
+    }
+
+    private void Update()
+    {
+        if (Vector3.Magnitude(_cursorOffset - _cco.m_Offset) < offsetThreshold)
         {
-            _cco.m_Offset = offset;
+            _cco.m_Offset = _cursorOffset;
             return;
         }
-        // _cco.m_Offset = offset;
-        _cco.m_Offset = Vector3.Lerp(_cco.m_Offset, offset, offsetSpeed * ts);
+        float movePercentage = Mathf.Clamp01(offsetSpeed * Time.deltaTime);
+        _cco.m_Offset = Vector3.Lerp(_cco.m_Offset, _cursorOffset, movePercentage);
     }
 }

--- a/Assets/Scripts/CameraOffset.cs.meta
+++ b/Assets/Scripts/CameraOffset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f794cfd6ba1440df87b323578e81c98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -20,6 +20,7 @@ public class Player : MonoBehaviour, IDamageable
     [SerializeField] private bool canAttack;
     [SerializeField] private bool canMove;
     [SerializeField] private CinemachineCameraOffset _cco;
+    [SerializeField] private CameraOffset cameraOffset;
     [SerializeField] private GameObject fireworkWavePrefab;
 
     [SerializeField] private PlayerWeaponBase[] weapons = new PlayerWeaponBase[2];
@@ -95,8 +96,10 @@ public class Player : MonoBehaviour, IDamageable
             escHoldTime = 0;
         }
 
-        if (_cco) {
-            _cco.m_Offset = Vector2.ClampMagnitude(aimDir, 1) * maxAimOffset;
+        if (_cco)
+        {
+            Vector3 offset = Vector2.ClampMagnitude(aimDir, 1) * maxAimOffset;
+            cameraOffset.OffsetTo(offset, Time.deltaTime);
         }
         if (!canMove) {
             moveDir = Vector2.zero;

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -99,7 +99,7 @@ public class Player : MonoBehaviour, IDamageable
         if (_cco)
         {
             Vector3 offset = Vector2.ClampMagnitude(aimDir, 1) * maxAimOffset;
-            cameraOffset.OffsetTo(offset, Time.deltaTime);
+            cameraOffset.OffsetTo(offset);
         }
         if (!canMove) {
             moveDir = Vector2.zero;


### PR DESCRIPTION
Smoothes camera by using linear interpolation towards the target offset with a set percentage every frame.

The offsetThreshold attempts to alleviate a weird snapping effect that happens as the camera gets really close to the target position (I think it's because it takes an unnaturally long time for the camera to travel the last pixel due to the exponential decay nature of using linear interpolation in this way).

The script has been changed to update position in the CameraOffset.Update() method instead of the Player's Update().

The added CameraOffset script is currently attached to the Cinemachine Camera Offset object in the M2_Tutorial scene.